### PR TITLE
Bugfix: Asset handling GitHub pages (via Angular environment)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,10 +2,10 @@ name: Deployment
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+    # branches:
+    #   - main
+    # tags:
+    #   - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deployment:
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
-        run: npm run test:ci
+      # - name: Run tests
+      #   run: npm run test:ci
 
       - name: Create build
         run: npm run build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,10 +2,10 @@ name: Deployment
 
 on:
   push:
-    # branches:
-    #   - main
-    # tags:
-    #   - '[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   deployment:
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # - name: Run tests
-      #   run: npm run test:ci
+      - name: Run tests
+        run: npm run test:ci
 
       - name: Create build
         run: npm run build:ghpages

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -24,7 +24,7 @@ jobs:
       #   run: npm run test:ci
 
       - name: Create build
-        run: npm run build
+        run: npm run build:ghpages
 
       - name: Deploy
         if: success()

--- a/angular.json
+++ b/angular.json
@@ -73,6 +73,31 @@
               "serviceWorker": true,
               "ngswConfigPath": "ngsw-config.json"
             },
+            "production-ghpages": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod-ghpages.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
+              "aot": true,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                }
+              ],
+              "serviceWorker": true,
+              "ngswConfigPath": "ngsw-config-ghpages.json"
+            },
             "development": {
               "optimization": false,
               "sourceMap": true,

--- a/ngsw-config-ghpages.json
+++ b/ngsw-config-ghpages.json
@@ -1,13 +1,13 @@
 {
   "$schema": "./node_modules/@angular/service-worker/config/schema.json",
-  "index": "/osmgo/index.html",
+  "index": "/OsmGo/index.html",
   "assetGroups": [
     {
       "name": "i18n",
       "installMode": "prefetch",
       "updateMode": "prefetch",
       "resources": {
-        "files": ["/osmgo/assets/i18n/**", "/osmgo/manifest.webmanifest"]
+        "files": ["/OsmGo/assets/i18n/**", "/osmgo/manifest.webmanifest"]
       }
     },
     {
@@ -15,37 +15,37 @@
       "installMode": "prefetch",
       "resources": {
         "files": [
-          "/osmgo/favicon.ico",
-          "/osmgo/index.html",
+          "/OsmGo/favicon.ico",
+          "/OsmGo/index.html",
           "*.css",
           "*.js",
-          "/osmgo/assets/osmtogeojson.js",
+          "/OsmGo/assets/osmtogeojson.js",
 
-          "/osmgo/svg/md-menu.svg",
-          "/osmgo/svg/md-refresh.svg",
-          "/osmgo/svg/md-image.svg",
-          "/osmgo/svg/md-arrow-back.svg",
-          "/osmgo/svg/md-add.svg",
-          "/osmgo/svg/md-locate.svg",
-          "/osmgo/svg/md-close.svg",
-          "/osmgo/svg/md-checkmark.svg",
-          "/osmgo/svg/md-code.svg",
-          "/osmgo/svg/md-move.svg",
-          "/osmgo/svg/md-settings.svg",
-          "/osmgo/svg/md-search.svg",
-          "/osmgo/svg/md-code-working.svg",
-          "/osmgo/svg/md-log-in.svg",
-          "/osmgo/svg/md-star.svg",
-          "/osmgo/svg/md-help-circle",
-          "/osmgo/svg/md-trash.svg",
-          "/osmgo/svg/md-help-circle.svg",
-          "/osmgo/svg/md-cloud-upload.svg",
-          "/osmgo/svg/md-heart.svg",
-          "/osmgo/svg/md-create.svg",
-          "/osmgo/svg/md-checkmark-circle-outline.svg",
-          "/osmgo/svg/md-time.svg",
-          "/osmgo/assets/ionicons/ionicons_save.svg",
-          "/osmgo/assets/ionicons/ionicons_restore-save.svg",
+          "/OsmGo/svg/md-menu.svg",
+          "/OsmGo/svg/md-refresh.svg",
+          "/OsmGo/svg/md-image.svg",
+          "/OsmGo/svg/md-arrow-back.svg",
+          "/OsmGo/svg/md-add.svg",
+          "/OsmGo/svg/md-locate.svg",
+          "/OsmGo/svg/md-close.svg",
+          "/OsmGo/svg/md-checkmark.svg",
+          "/OsmGo/svg/md-code.svg",
+          "/OsmGo/svg/md-move.svg",
+          "/OsmGo/svg/md-settings.svg",
+          "/OsmGo/svg/md-search.svg",
+          "/OsmGo/svg/md-code-working.svg",
+          "/OsmGo/svg/md-log-in.svg",
+          "/OsmGo/svg/md-star.svg",
+          "/OsmGo/svg/md-help-circle",
+          "/OsmGo/svg/md-trash.svg",
+          "/OsmGo/svg/md-help-circle.svg",
+          "/OsmGo/svg/md-cloud-upload.svg",
+          "/OsmGo/svg/md-heart.svg",
+          "/OsmGo/svg/md-create.svg",
+          "/OsmGo/svg/md-checkmark-circle-outline.svg",
+          "/OsmGo/svg/md-time.svg",
+          "/OsmGo/assets/ionicons/ionicons_save.svg",
+          "/OsmGo/assets/ionicons/ionicons_restore-save.svg",
           "*.png"
         ]
       }
@@ -57,7 +57,7 @@
       "updateMode": "prefetch",
       "resources": {
         "files": [
-          "/osmgo/assets/**",
+          "/OsmGo/assets/**",
           "/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
         ]
       }

--- a/ngsw-config-ghpages.json
+++ b/ngsw-config-ghpages.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "./node_modules/@angular/service-worker/config/schema.json",
+  "index": "/osmgo/index.html",
+  "assetGroups": [
+    {
+      "name": "i18n",
+      "installMode": "prefetch",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": ["/osmgo/assets/i18n/**", "/osmgo/manifest.webmanifest"]
+      }
+    },
+    {
+      "name": "app",
+      "installMode": "prefetch",
+      "resources": {
+        "files": [
+          "/osmgo/favicon.ico",
+          "/osmgo/index.html",
+          "*.css",
+          "*.js",
+          "/osmgo/assets/osmtogeojson.js",
+
+          "/osmgo/svg/md-menu.svg",
+          "/osmgo/svg/md-refresh.svg",
+          "/osmgo/svg/md-image.svg",
+          "/osmgo/svg/md-arrow-back.svg",
+          "/osmgo/svg/md-add.svg",
+          "/osmgo/svg/md-locate.svg",
+          "/osmgo/svg/md-close.svg",
+          "/osmgo/svg/md-checkmark.svg",
+          "/osmgo/svg/md-code.svg",
+          "/osmgo/svg/md-move.svg",
+          "/osmgo/svg/md-settings.svg",
+          "/osmgo/svg/md-search.svg",
+          "/osmgo/svg/md-code-working.svg",
+          "/osmgo/svg/md-log-in.svg",
+          "/osmgo/svg/md-star.svg",
+          "/osmgo/svg/md-help-circle",
+          "/osmgo/svg/md-trash.svg",
+          "/osmgo/svg/md-help-circle.svg",
+          "/osmgo/svg/md-cloud-upload.svg",
+          "/osmgo/svg/md-heart.svg",
+          "/osmgo/svg/md-create.svg",
+          "/osmgo/svg/md-checkmark-circle-outline.svg",
+          "/osmgo/svg/md-time.svg",
+          "/osmgo/assets/ionicons/ionicons_save.svg",
+          "/osmgo/assets/ionicons/ionicons_restore-save.svg",
+          "*.png"
+        ]
+      }
+    },
+
+    {
+      "name": "assets",
+      "installMode": "lazy",
+      "updateMode": "prefetch",
+      "resources": {
+        "files": [
+          "/osmgo/assets/**",
+          "/*.(eot|svg|cur|jpg|png|webp|gif|otf|ttf|woff|woff2|ani)"
+        ]
+      }
+    }
+  ],
+  "dataGroups": [
+    {
+      "name": "tilesMap",
+      "urls": [
+        "https://a.tiles.mapbox.com/**",
+        "https://b.tiles.mapbox.com/**",
+        "https://c.tiles.mapbox.com/**",
+
+        "https://api.mapbox.com/v4/**",
+
+        "https://wxs.ign.fr/pratique/geoportail/**",
+
+        "https://ecn.t0.tiles.virtualearth.net/**",
+        "https://ecn.t1.tiles.virtualearth.net/**",
+        "https://ecn.t2.tiles.virtualearth.net/**",
+        "https://ecn.t3.tiles.virtualearth.net/**"
+      ],
+      "cacheConfig": {
+        "maxSize": 800,
+        "maxAge": "15d",
+        "strategy": "performance"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ng": "ng",
     "start": "ng serve --host 0.0.0.0",
     "build": "ng build --configuration production",
+    "build:ghpages": "ng build --configuration production-ghpages",
     "test": "ng test --ts-config src/tsconfig.spec.json --browsers Chrome",
     "test:coverage": "npm run test -- --code-coverage",
     "test:ci": "ng test --ts-config src/tsconfig.spec.json --watch=false --browsers=ChromeHeadlessCI --code-coverage",

--- a/src/app/components/icon/icon.component.html
+++ b/src/app/components/icon/icon.component.html
@@ -5,7 +5,8 @@
         [style.width]="conf.width + 'px'"
         [style.height]="conf.height + 'px'"
         [style.background-position]="'-' + conf.x + 'px -' + conf.y + 'px'"
-        [className]="'spritesX' + devicePixelRatio"
+        className="sprites"
+        [style.background-image]="spriteUrl"
     ></div>
 
     <div
@@ -20,6 +21,7 @@
             jsonSprites['wiki_question'].y +
             'px'
         "
-        [className]="'spritesX' + devicePixelRatio"
+        className="sprites"
+        [style.background-image]="spriteUrl"
     ></div>
 </div>

--- a/src/app/components/icon/icon.component.scss
+++ b/src/app/components/icon/icon.component.scss
@@ -1,9 +1,7 @@
-.spritesX1 {
-    background: url('/assets/iconsSprites@x1.png') 0 0 no-repeat;
-}
-
-.spritesX2 {
-    background: url('/assets/iconsSprites@x2.png') 0 0 no-repeat;
+.sprites {
+    background-position-x: 0;
+    background-position-y: 0;
+    background-repeat: no-repeat;
 }
 
 .iconWrapper {

--- a/src/app/components/icon/icon.component.ts
+++ b/src/app/components/icon/icon.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, Input } from '@angular/core'
+import { environment } from '@environments/environment'
 
 @Component({
     selector: 'app-icon',
@@ -16,5 +17,10 @@ export class IconComponent implements OnInit {
 
     ngOnInit() {
         this.devicePixelRatio = window.devicePixelRatio > 1 ? 2 : 1
+    }
+
+    get spriteUrl() {
+        const basePath = environment.urlBasePath || ''
+        return `url(${basePath}/assets/iconsSprites@x${this.devicePixelRatio}.png)`
     }
 }

--- a/src/app/components/modal/modal.html
+++ b/src/app/components/modal/modal.html
@@ -159,7 +159,9 @@
                         size="small"
                         (click)="saveFields(tagId, tags)"
                     >
-                        <ion-icon src="/assets/fa/copy-solid.svg"></ion-icon>
+                        <ion-icon
+                            [src]="getAssetPath('/fa/copy-solid.svg')"
+                        ></ion-icon>
                     </ion-fab-button>
                 </ion-fab>
 
@@ -168,7 +170,9 @@
                         size="small"
                         (click)="restoreFields(tagId, tags)"
                     >
-                        <ion-icon src="/assets/fa/paste-solid.svg"></ion-icon>
+                        <ion-icon
+                            [src]="getAssetPath('/fa/paste-solid.svg')"
+                        ></ion-icon>
                     </ion-fab-button>
                 </ion-fab>
             </div>

--- a/src/app/components/modal/modal.ts
+++ b/src/app/components/modal/modal.ts
@@ -34,6 +34,7 @@ import {
     Point,
     Polygon,
 } from 'geojson'
+import { environment } from '@environments/environment'
 
 export interface ModalDismissData {
     redraw?: boolean
@@ -660,5 +661,12 @@ export class ModalsContentPage implements OnInit {
             this.tagsService.removeBookMark(tag)
         }
         this.cdr.detectChanges()
+    }
+
+    /** Resolve a path relative to the assets folder. */
+    getAssetPath(relPath: string): string {
+        const relPathPatched = relPath.startsWith('/') ? relPath : '/' + relPath
+        const basePath = environment.urlBasePath || ''
+        return `${basePath}/assets${relPathPatched}`
     }
 }

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -52,6 +52,7 @@ import { Config } from 'protractor'
 import { BehaviorSubject, Observable, of, Subject, Subscription } from 'rxjs'
 import { Feature, FeatureCollection, LineString } from 'geojson'
 import { ModalDismissData } from '../components/modal/modal'
+import { environment } from '@environments/environment'
 
 @Injectable({ providedIn: 'root' })
 export class MapService {
@@ -171,20 +172,22 @@ export class MapService {
 
     loadUnknownMarker(factor: number): void {
         const roundedFactor = factor > 1 ? 2 : 1
+        const basePath = environment.urlBasePath || ''
+        const pathPrefix = `${basePath}/assets/mapStyle/unknown-marker`
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/circle-unknown@${roundedFactor}X.png`,
+            `${pathPrefix}/circle-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['circle'] = image
             }
         )
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/penta-unknown@${roundedFactor}X.png`,
+            `${pathPrefix}/penta-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['penta'] = image
             }
         )
         this.map.loadImage(
-            `/assets/mapStyle/unknown-marker/square-unknown@${roundedFactor}X.png`,
+            `${pathPrefix}/square-unknown@${roundedFactor}X.png`,
             (error, image) => {
                 this.markerMaplibreUnknown['square'] = image
             }
@@ -555,8 +558,9 @@ export class MapService {
             map((maplibreStyle) => {
                 let spritesFullPath = `mapStyle/sprites/sprites`
                 // http://localhost:8100/assets/mapStyle/sprites/sprites.json
-                const basePath = window.location.origin // path.split('#')[0];
-                spritesFullPath = `${basePath}/assets/${spritesFullPath}`
+                const origin = window.location.origin // path.split('#')[0];
+                const basePath = environment.urlBasePath || ''
+                spritesFullPath = `${origin}${basePath}/assets/${spritesFullPath}`
 
                 maplibreStyle['sprite'] = spritesFullPath
                 return maplibreStyle

--- a/src/app/services/osmApi.service.ts
+++ b/src/app/services/osmApi.service.ts
@@ -19,6 +19,7 @@ import { Platform } from '@ionic/angular'
 import { addAttributesToFeature } from '@scripts/osmToOsmgo/index.js'
 
 import { XMLParser } from 'fast-xml-parser'
+import { environment } from '@environments/environment'
 
 @Injectable({ providedIn: 'root' })
 export class OsmApiService {
@@ -51,7 +52,8 @@ export class OsmApiService {
     ) {}
 
     initAuth() {
-        const landing = `${window.location.origin}/assets/land.html` // land_single.html
+        const basePath = environment.urlBasePath || ''
+        const landing = `${basePath}/assets/land.html` // land_single.html
         const windowType = 'newFullPage' // singlepage, popup, newFullPage
 
         this.auth = new osmAuth.default({

--- a/src/environments/environment.prod-ghpages.ts
+++ b/src/environments/environment.prod-ghpages.ts
@@ -1,5 +1,5 @@
 export const environment = {
     production: true,
     version: '1.5.0',
-    urlBasePath: '/osmgo',
+    urlBasePath: '/OsmGo',
 }

--- a/src/environments/environment.prod-ghpages.ts
+++ b/src/environments/environment.prod-ghpages.ts
@@ -1,0 +1,5 @@
+export const environment = {
+    production: true,
+    version: '1.5.0',
+    urlBasePath: '/osmgo',
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -2,7 +2,9 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import { Environment } from '@osmgo/type'
+
+export const environment: Environment = {
     production: false,
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -172,3 +172,9 @@ export interface CountryCode {
     /** Numeric ISO 3166-1 country code */
     'country-code': string
 }
+
+export interface Environment {
+    production: boolean
+    version?: string
+    urlBasePath?: string
+}


### PR DESCRIPTION
Since GitHub Pages URLs have the form `https://<username>.github.io/<reponame>`, it's not possible to link static assets against the root directory, e.g., by using a path `/assets/foobar`. Instead a base path prefix is needed, in this case `/OsmGo`.
This PR introduces an Angular environment variable `urlBasePath` which can be set and needs to be respected in all components or services that refer to static assets. Also the service worker configuration has been forked and the `/OsmGo` prefix has been added to relevant routes. A build target `npm run build:ghpages` has been added and will be used in the GitHub Actions workflow that deploys the code to GitHub Pages.

This PR fixes #7 and acts as a replacement for #8.